### PR TITLE
release for v2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@
 ### 🌍 Multi-Language Support (NEW in v2.2.0!)
 
 * **11 languages included** - English, German, French, Spanish, Italian, Dutch, Portuguese, Polish, Swedish, Danish, Norwegian
-* **Automatic translation** - All labels translate based on selected language
+* **Automatic detection** - Uses your Home Assistant language setting automatically
+* **Zero configuration** - No need to manually select language
 * **Seamless integration** - Works alongside custom labels (custom labels take priority)
 * **Easy to extend** - Clean translation structure for adding more languages
 
@@ -254,9 +255,21 @@ use_solcast: true
 | `show_legend_values`      | boolean | `true`            | 🔢 Show kW values in legend                                                                                                   |
 | `show_bar_label`          | boolean | `true`            | 🏷️ Show power distribution label above bar                                                                                  |
 | `show_bar_values`         | boolean | `true`            | 📊 Show kW values on bar segments                                                                                             |
-| `custom_labels`           | object  | `{}`              | 🏷️ Custom labels for items - NEW in v2.2.0 (see Custom Labels section)                                                      |
-| `tap_actions`             | object  | `{}`              | 🖱️ Tap action configuration per element - NEW in v2.2.0 (see Tap Actions section)                                           |
-| `language`                | string  | `"en"`            | 🌍 Language for card labels - NEW in v2.2.0 (see Multi-Language section)                                                     |
+| `label_solar`             | string  | `null`            | 🏷️ Custom label for Solar - NEW in v2.2.0 (configure via UI)                                                                |
+| `label_import`            | string  | `null`            | 🏷️ Custom label for Import - NEW in v2.2.0 (configure via UI)                                                               |
+| `label_export`            | string  | `null`            | 🏷️ Custom label for Export - NEW in v2.2.0 (configure via UI)                                                               |
+| `label_usage`             | string  | `null`            | 🏷️ Custom label for Usage - NEW in v2.2.0 (configure via UI)                                                                |
+| `label_battery`           | string  | `null`            | 🏷️ Custom label for Battery - NEW in v2.2.0 (configure via UI)                                                              |
+| `label_ev`                | string  | `null`            | 🏷️ Custom label for EV - NEW in v2.2.0 (configure via UI)                                                                   |
+| `label_power_flow`        | string  | `null`            | 🏷️ Custom label for Power Flow - NEW in v2.2.0 (configure via UI)                                                           |
+| `tap_action_solar`        | object  | `{action: "more-info"}` | 🖱️ Tap action for Solar elements - NEW in v2.2.0 (configure via UI)                                                   |
+| `tap_action_import`       | object  | `{action: "more-info"}` | 🖱️ Tap action for Import elements - NEW in v2.2.0 (configure via UI)                                                  |
+| `tap_action_export`       | object  | `{action: "more-info"}` | 🖱️ Tap action for Export elements - NEW in v2.2.0 (configure via UI)                                                  |
+| `tap_action_usage`        | object  | `{action: "more-info"}` | 🖱️ Tap action for Usage elements - NEW in v2.2.0 (configure via UI)                                                   |
+| `tap_action_battery`      | object  | `{action: "more-info"}` | 🖱️ Tap action for Battery elements - NEW in v2.2.0 (configure via UI)                                                 |
+| `tap_action_ev`           | object  | `{action: "more-info"}` | 🖱️ Tap action for EV elements - NEW in v2.2.0 (configure via UI)                                                      |
+
+**Note:** Language is automatically detected from your Home Assistant language setting. Custom labels override auto-detected translations.
 
 ---
 
@@ -373,29 +386,28 @@ production_entity: sensor.solar_production_power
 self_consumption_entity: sensor.home_consumption
 export_entity: sensor.grid_export_power
 import_entity: sensor.grid_import_power
-custom_labels:
-  solar: "PV"
-  import: "Grid In"
-  export: "Grid Out"
-  usage: "Home"
-  battery: "Storage"
-  ev: "Car"
-  power_flow: "Energy Flow"
+label_solar: "PV"
+label_import: "Grid In"
+label_export: "Grid Out"
+label_usage: "Home"
+label_battery: "Storage"
+label_ev: "Car"
+label_power_flow: "Energy Flow"
 ```
 
 ### Using the Visual Editor
 
 1. Add or edit the Solar Bar Card
 2. Expand the **🏷️ Custom Labels** section
-3. Click the "+" button to add label overrides
-4. Enter key-value pairs (e.g., `solar: "PV"`, `import: "Grid In"`)
+3. Enter custom labels in the text fields (leave empty to use auto-detected language)
+4. Each label has its own field with a clear description
 5. Labels update immediately in the preview
 
 ### Fallback Behavior
 
-- If a label is not set in `custom_labels`, the card uses the language translation
-- If language is not set, defaults to English
-- You can mix custom labels with translated labels (custom takes priority)
+- If a label is not set, the card uses the auto-detected language translation (from Home Assistant settings)
+- Custom labels override translations
+- If Home Assistant language is not supported, defaults to English
 
 ---
 
@@ -433,13 +445,12 @@ type: custom:solar-bar-card
 inverter_size: 10
 production_entity: sensor.solar_production_power
 self_consumption_entity: sensor.home_consumption
-tap_actions:
-  solar:
-    action: navigate
-    navigation_path: /dashboard-solar
-  battery:
-    action: navigate
-    navigation_path: /dashboard-energy
+tap_action_solar:
+  action: navigate
+  navigation_path: /dashboard-solar
+tap_action_battery:
+  action: navigate
+  navigation_path: /dashboard-energy
 ```
 
 #### Call Service
@@ -449,15 +460,14 @@ type: custom:solar-bar-card
 inverter_size: 10
 production_entity: sensor.solar_production_power
 self_consumption_entity: sensor.home_consumption
-tap_actions:
-  battery:
-    action: call-service
-    service: switch.toggle
-    service_data:
-      entity_id: switch.battery_charge_control
-  ev:
-    action: call-service
-    service: script.start_ev_charging
+tap_action_battery:
+  action: call-service
+  service: switch.toggle
+  service_data:
+    entity_id: switch.battery_charge_control
+tap_action_ev:
+  action: call-service
+  service: script.start_ev_charging
 ```
 
 #### Open URL
@@ -467,10 +477,9 @@ type: custom:solar-bar-card
 inverter_size: 10
 production_entity: sensor.solar_production_power
 self_consumption_entity: sensor.home_consumption
-tap_actions:
-  solar:
-    action: url
-    url_path: https://pvoutput.org/list.jsp
+tap_action_solar:
+  action: url
+  url_path: https://pvoutput.org/list.jsp
 ```
 
 #### Disable Tap Action
@@ -480,26 +489,26 @@ type: custom:solar-bar-card
 inverter_size: 10
 production_entity: sensor.solar_production_power
 self_consumption_entity: sensor.home_consumption
-tap_actions:
-  import:
-    action: none
-  export:
-    action: none
+tap_action_import:
+  action: none
+tap_action_export:
+  action: none
 ```
 
 ### Using the Visual Editor
 
 1. Add or edit the Solar Bar Card
 2. Expand the **🖱️ Tap Actions** section
-3. Click the "+" button to add action overrides
-4. Enter the action key (e.g., `solar`) and action configuration
-5. Example: `solar: {action: "navigate", navigation_path: "/dashboard-solar"}`
+3. For each element (Solar, Import, Export, Usage, Battery, EV), use Home Assistant's standard action selector
+4. Choose action type from dropdown (more-info, navigate, call-service, url, none)
+5. Configure action parameters based on selected action type
+6. Changes apply immediately
 
 ---
 
 ## 🌍 Multi-Language Support
 
-The card includes built-in translations for 11 languages. All labels automatically translate based on your selected language.
+The card includes built-in translations for 11 languages. **Language is automatically detected** from your Home Assistant language setting - no configuration needed!
 
 ### Supported Languages
 
@@ -517,7 +526,22 @@ The card includes built-in translations for 11 languages. All labels automatical
 | `da`          | Danish     | Sol, Import, Eksport, Forbrug, Batteri, EV, etc.           |
 | `no`          | Norwegian  | Sol, Import, Eksport, Forbruk, Batteri, EV, etc.           |
 
-### Example Configuration
+### How It Works
+
+The card automatically detects your language from:
+1. **Home Assistant language setting** (Settings → System → General → Language)
+2. If not supported, falls back to English
+
+**No configuration needed!** The card uses your Home Assistant language automatically.
+
+### Priority Order
+
+Labels are resolved in this order:
+1. **Custom Labels** (highest priority) - If set via `label_*` config options
+2. **Auto-Detected Language** - Based on your Home Assistant language setting
+3. **English Fallback** - If language not supported
+
+### Example with Custom Labels
 
 ```yaml
 type: custom:solar-bar-card
@@ -526,29 +550,10 @@ production_entity: sensor.solar_production_power
 self_consumption_entity: sensor.home_consumption
 export_entity: sensor.grid_export_power
 import_entity: sensor.grid_import_power
-language: de  # German
-```
-
-### Using the Visual Editor
-
-1. Add or edit the Solar Bar Card
-2. Expand the **🌍 Language** section
-3. Select your preferred language from the dropdown
-4. All labels update immediately
-
-### Priority Order
-
-Labels are resolved in this order:
-1. **Custom Labels** (highest priority) - If set in `custom_labels`
-2. **Language Translations** - Based on selected `language`
-3. **English Fallback** - If language not found or key missing
-
-Example:
-```yaml
-language: de  # German
-custom_labels:
-  solar: "PV-Anlage"  # Custom label overrides German translation
-  # Other labels use German translations
+# Language auto-detected from HA settings (e.g., German)
+label_solar: "PV-Anlage"  # Custom label overrides auto-detected German translation
+label_battery: "Speicher"  # Custom label overrides auto-detected German translation
+# Other labels automatically use German translations
 ```
 
 ---

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -14,17 +14,19 @@ You can now customize all labels displayed in the card! Rename any item to match
 
 **Configuration Example:**
 ```yaml
-custom_labels:
-  solar: "PV"
-  import: "Grid In"
-  export: "Grid Out"
-  usage: "Home"
-  battery: "Storage"
-  ev: "Car"
-  power_flow: "Energy Flow"
+label_solar: "PV"
+label_import: "Grid In"
+label_export: "Grid Out"
+label_usage: "Home"
+label_battery: "Storage"
+label_ev: "Car"
+label_power_flow: "Energy Flow"
 ```
 
-Custom labels appear everywhere: stats tiles, legend, bar segments, and tooltips.
+**UI Configuration:**
+- Each label has its own text field in the "Custom Labels" section
+- Leave empty to use auto-detected language translation
+- Custom labels appear everywhere: stats tiles, legend, bar segments, and tooltips
 
 ---
 
@@ -40,26 +42,31 @@ Each element in the card can now have its own tap action! No more being limited 
 
 **Configuration Example:**
 ```yaml
-tap_actions:
-  solar:
-    action: navigate
-    navigation_path: /dashboard-solar
-  battery:
-    action: call-service
-    service: switch.toggle
-    service_data:
-      entity_id: switch.battery_charge_control
-  import:
-    action: url
-    url_path: https://pvoutput.org
+tap_action_solar:
+  action: navigate
+  navigation_path: /dashboard-solar
+tap_action_battery:
+  action: call-service
+  service: switch.toggle
+  service_data:
+    entity_id: switch.battery_charge_control
+tap_action_import:
+  action: url
+  url_path: https://pvoutput.org
 ```
 
-**Available Action Keys:** `solar`, `import`, `export`, `usage`, `battery`, `ev`
+**UI Configuration:**
+- Each element has its own action selector using Home Assistant's standard `ui-action` control
+- Choose action type from dropdown (more-info, navigate, call-service, url, none)
+- Configure action parameters based on selected type
+- Visual, user-friendly interface - no manual YAML editing needed
+
+**Available Elements:** `solar`, `import`, `export`, `usage`, `battery`, `ev`
 
 ---
 
 ### 🌍 Multi-Language Support
-The card now includes built-in translations for 11 languages!
+The card now includes built-in translations for 11 languages with **automatic detection** from your Home Assistant language setting!
 
 **Supported Languages:**
 - 🇬🇧 English (en)
@@ -74,19 +81,17 @@ The card now includes built-in translations for 11 languages!
 - 🇩🇰 Danish (da)
 - 🇳🇴 Norwegian (no)
 
-**Configuration Example:**
-```yaml
-language: de  # German
-```
-
-All labels automatically translate: Solar, Import, Export, Usage, Battery, EV, Power Flow, tooltips, and messages.
+**Zero Configuration:**
+- Language is automatically detected from your Home Assistant language setting (Settings → System → General → Language)
+- No manual configuration needed!
+- All labels automatically translate: Solar, Import, Export, Usage, Battery, EV, Power Flow, tooltips, and messages
 
 **Priority Order:**
-1. Custom Labels (highest)
-2. Language Translations
+1. Custom Labels (highest priority)
+2. Auto-Detected Language Translation
 3. English Fallback
 
-You can mix custom labels with translations - custom labels override translated labels for specific items.
+You can mix custom labels with auto-detected translations - custom labels override translated labels for specific items.
 
 ---
 
@@ -98,7 +103,7 @@ This release adds three powerful customization features that work seamlessly tog
 2. **Tap Actions** - Make your card interactive with custom actions for each element
 3. **Multi-Language** - Use the card in your native language
 
-### Example: German Card with Custom Labels and Actions
+### Example: Card with Auto-Detected Language, Custom Labels, and Actions
 
 ```yaml
 type: custom:solar-bar-card
@@ -107,28 +112,39 @@ production_entity: sensor.solar_production_power
 self_consumption_entity: sensor.home_consumption
 export_entity: sensor.grid_export_power
 import_entity: sensor.grid_import_power
-language: de
-custom_labels:
-  solar: "PV-Anlage"  # Override translation for solar only
-  battery: "Speicher"
-tap_actions:
-  solar:
-    action: navigate
-    navigation_path: /dashboard-solar
-  battery:
-    action: navigate
-    navigation_path: /dashboard-battery
+# Language auto-detected from HA settings (e.g., German)
+label_solar: "PV-Anlage"  # Override auto-detected translation
+label_battery: "Speicher"  # Override auto-detected translation
+# Other labels use auto-detected German translations
+tap_action_solar:
+  action: navigate
+  navigation_path: /dashboard-solar
+tap_action_battery:
+  action: navigate
+  navigation_path: /dashboard-battery
 ```
 
 ---
 
 ## 🎨 UI Configuration
 
-All new features are fully integrated into the visual configuration editor:
+All new features are fully integrated into the visual configuration editor with native Home Assistant controls:
 
-- **Custom Labels Section** - Add/edit label overrides with object editor
-- **Tap Actions Section** - Configure actions per element with object editor
-- **Language Section** - Dropdown selector with all 11 languages
+- **Custom Labels Section**
+  - Individual text fields for each label (Solar, Import, Export, Usage, Battery, EV, Power Flow)
+  - Grid layout for easy organization
+  - Clear descriptions for each field
+  - Leave empty to use auto-detected language
+
+- **Tap Actions Section**
+  - Uses Home Assistant's standard `ui-action` selector for each element
+  - Visual dropdown interface - no manual YAML needed
+  - Action type selector with parameter fields
+  - Per-element configuration (Solar, Import, Export, Usage, Battery, EV)
+
+- **Language**
+  - Automatically detected from Home Assistant settings
+  - No UI configuration needed!
 
 ---
 
@@ -138,9 +154,19 @@ All new features are fully integrated into the visual configuration editor:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `custom_labels` | object | `{}` | Custom label overrides |
-| `tap_actions` | object | `{}` | Tap action configuration per element |
-| `language` | string | `"en"` | Language code for translations |
+| `label_solar` | string | `null` | Custom label for Solar |
+| `label_import` | string | `null` | Custom label for Import |
+| `label_export` | string | `null` | Custom label for Export |
+| `label_usage` | string | `null` | Custom label for Usage |
+| `label_battery` | string | `null` | Custom label for Battery |
+| `label_ev` | string | `null` | Custom label for EV |
+| `label_power_flow` | string | `null` | Custom label for Power Flow |
+| `tap_action_solar` | object | `{action: "more-info"}` | Tap action for Solar elements |
+| `tap_action_import` | object | `{action: "more-info"}` | Tap action for Import elements |
+| `tap_action_export` | object | `{action: "more-info"}` | Tap action for Export elements |
+| `tap_action_usage` | object | `{action: "more-info"}` | Tap action for Usage elements |
+| `tap_action_battery` | object | `{action: "more-info"}` | Tap action for Battery elements |
+| `tap_action_ev` | object | `{action: "more-info"}` | Tap action for EV elements |
 
 ### Breaking Changes
 
@@ -150,8 +176,8 @@ None! This release is fully backward compatible. All existing configurations wil
 
 - If you don't configure these new options, the card behaves exactly as it did in v2.1.2
 - Default tap action is `more-info` (entity history)
-- Default language is English
-- Default labels are in English
+- Language is auto-detected from Home Assistant settings
+- Default labels use auto-detected language (or English fallback)
 
 ---
 


### PR DESCRIPTION
# Solar Bar Card v2.2.0 Release Notes

## 🎉 Major New Features

### 🏷️ Custom Labels

You can now customize all labels displayed in the card! Rename any item to match your preferences:

- Solar → "PV", "Panels", or any custom name
- Import → "Grid In", "Netzbezug", etc.
- Export → "Grid Out", "Feed-in", etc.
- Usage → "Home", "Consumption", etc.
- Battery → "Storage", "Accu", etc.
- EV → "Car", "Charger", etc.
- Power Flow → "Energy Flow", "Distribution", etc.

**Configuration Example:**

```yaml
label_solar: "PV"
label_import: "Grid In"
label_export: "Grid Out"
label_usage: "Home"
label_battery: "Storage"
label_ev: "Car"
label_power_flow: "Energy Flow"
```

**UI Configuration:**

- Each label has its own text field in the "Custom Labels" section
- Leave empty to use auto-detected language translation
- Custom labels appear everywhere: stats tiles, legend, bar segments, and tooltips

---

### 🖱️ Configurable Tap Actions

Each element in the card can now have its own tap action! No more being limited to just entity history.

**Supported Actions:**

- `more-info` - Show entity history (default)
- `navigate` - Go to a dashboard or view
- `call-service` - Trigger any Home Assistant service
- `url` - Open an external URL
- `none` - Disable tap action

**Configuration Example:**

```yaml
tap_action_solar:
  action: navigate
  navigation_path: /dashboard-solar
tap_action_battery:
  action: call-service
  service: switch.toggle
  service_data:
    entity_id: switch.battery_charge_control
tap_action_import:
  action: url
  url_path: https://pvoutput.org
```

**UI Configuration:**

- Each element has its own action selector using Home Assistant's standard `ui-action` control
- Choose action type from dropdown (more-info, navigate, call-service, url, none)
- Configure action parameters based on selected type
- Visual, user-friendly interface - no manual YAML editing needed

**Available Elements:** `solar`, `import`, `export`, `usage`, `battery`, `ev`

---

### 🌍 Multi-Language Support

The card now includes built-in translations for 11 languages with **automatic detection** from your Home Assistant language setting!

**Supported Languages:**

- 🇬🇧 English (en)
- 🇩🇪 German (de)
- 🇫🇷 French (fr)
- 🇪🇸 Spanish (es)
- 🇮🇹 Italian (it)
- 🇳🇱 Dutch (nl)
- 🇵🇹 Portuguese (pt)
- 🇵🇱 Polish (pl)
- 🇸🇪 Swedish (sv)
- 🇩🇰 Danish (da)
- 🇳🇴 Norwegian (no)

**Zero Configuration:**

- Language is automatically detected from your Home Assistant language setting (Settings → System → General → Language)
- No manual configuration needed!
- All labels automatically translate: Solar, Import, Export, Usage, Battery, EV, Power Flow, tooltips, and messages

**Priority Order:**

1. Custom Labels (highest priority)
2. Auto-Detected Language Translation
3. English Fallback

You can mix custom labels with auto-detected translations - custom labels override translated labels for specific items.

---

## 📋 Summary

This release adds three powerful customization features that work seamlessly together:

1. **Custom Labels** - Personalize your card with your preferred terminology
2. **Tap Actions** - Make your card interactive with custom actions for each element
3. **Multi-Language** - Use the card in your native language

### Example: Card with Auto-Detected Language, Custom Labels, and Actions

```yaml
type: custom:solar-bar-card
inverter_size: 10
production_entity: sensor.solar_production_power
self_consumption_entity: sensor.home_consumption
export_entity: sensor.grid_export_power
import_entity: sensor.grid_import_power
# Language auto-detected from HA settings (e.g., German)
label_solar: "PV-Anlage"  # Override auto-detected translation
label_battery: "Speicher"  # Override auto-detected translation
# Other labels use auto-detected German translations
tap_action_solar:
  action: navigate
  navigation_path: /dashboard-solar
tap_action_battery:
  action: navigate
  navigation_path: /dashboard-battery
```

---

## 🎨 UI Configuration

All new features are fully integrated into the visual configuration editor with native Home Assistant controls:

- **Custom Labels Section**

  - Individual text fields for each label (Solar, Import, Export, Usage, Battery, EV, Power Flow)
  - Grid layout for easy organization
  - Clear descriptions for each field
  - Leave empty to use auto-detected language
- **Tap Actions Section**

  - Uses Home Assistant's standard `ui-action` selector for each element
  - Visual dropdown interface - no manual YAML needed
  - Action type selector with parameter fields
  - Per-element configuration (Solar, Import, Export, Usage, Battery, EV)
- **Language**

  - Automatically detected from Home Assistant settings
  - No UI configuration needed!

---

## 🔧 Technical Details

### New Configuration Options


| Option               | Type   | Default                 | Description                     |
| ---------------------- | -------- | ------------------------- | --------------------------------- |
| `label_solar`        | string | `null`                  | Custom label for Solar          |
| `label_import`       | string | `null`                  | Custom label for Import         |
| `label_export`       | string | `null`                  | Custom label for Export         |
| `label_usage`        | string | `null`                  | Custom label for Usage          |
| `label_battery`      | string | `null`                  | Custom label for Battery        |
| `label_ev`           | string | `null`                  | Custom label for EV             |
| `label_power_flow`   | string | `null`                  | Custom label for Power Flow     |
| `tap_action_solar`   | object | `{action: "more-info"}` | Tap action for Solar elements   |
| `tap_action_import`  | object | `{action: "more-info"}` | Tap action for Import elements  |
| `tap_action_export`  | object | `{action: "more-info"}` | Tap action for Export elements  |
| `tap_action_usage`   | object | `{action: "more-info"}` | Tap action for Usage elements   |
| `tap_action_battery` | object | `{action: "more-info"}` | Tap action for Battery elements |
| `tap_action_ev`      | object | `{action: "more-info"}` | Tap action for EV elements      |

### Breaking Changes

None! This release is fully backward compatible. All existing configurations will continue to work exactly as before.

### Default Behavior

- If you don't configure these new options, the card behaves exactly as it did in v2.1.2
- Default tap action is `more-info` (entity history)
- Language is auto-detected from Home Assistant settings
- Default labels use auto-detected language (or English fallback)

---

## 📚 Documentation

Full documentation for all new features has been added to the [README.md](README.md):

- [Custom Labels Section](README.md#-custom-labels)
- [Tap Actions Section](README.md#-tap-actions)
- [Multi-Language Support Section](README.md#-multi-language-support)

---


Fixes #40, #41
## 🙏 Feedback

Please report any issues or feature requests on [GitHub Issues](https://github.com/0xAHA/solar-bar-card/issues).

---

**Full Changelog:** v2.1.2...v2.2.0