### PR TITLE
feat: add grid icon tower color config, fix idle circle transparency

### DIFF
--- a/dist/solar-bar-card-palettes.js
+++ b/dist/solar-bar-card-palettes.js
@@ -27,7 +27,8 @@ export const COLOR_PALETTES = {
       stats_consumer_2_background: null,
       grid_icon_import: null,
       grid_icon_export: null,
-      grid_icon_idle: null
+      grid_icon_idle: null,
+      grid_icon_color: null
     }
   },
   'soft-meadow': {
@@ -54,7 +55,8 @@ export const COLOR_PALETTES = {
       stats_consumer_2_background: null,
       grid_icon_import: null,
       grid_icon_export: null,
-      grid_icon_idle: null
+      grid_icon_idle: null,
+      grid_icon_color: null
     }
   },
   'ocean-sunset': {
@@ -81,7 +83,8 @@ export const COLOR_PALETTES = {
       stats_consumer_2_background: null,
       grid_icon_import: null,
       grid_icon_export: null,
-      grid_icon_idle: null
+      grid_icon_idle: null,
+      grid_icon_color: null
     }
   },
   'garden-fresh': {
@@ -108,7 +111,8 @@ export const COLOR_PALETTES = {
       stats_consumer_2_background: null,
       grid_icon_import: null,
       grid_icon_export: null,
-      grid_icon_idle: null
+      grid_icon_idle: null,
+      grid_icon_color: null
     }
   },
   'peachy-keen': {
@@ -135,7 +139,8 @@ export const COLOR_PALETTES = {
       stats_consumer_2_background: null,
       grid_icon_import: null,
       grid_icon_export: null,
-      grid_icon_idle: null
+      grid_icon_idle: null,
+      grid_icon_color: null
     }
   },
   'cloudy-day': {
@@ -162,7 +167,8 @@ export const COLOR_PALETTES = {
       stats_consumer_2_background: null,
       grid_icon_import: null,
       grid_icon_export: null,
-      grid_icon_idle: null
+      grid_icon_idle: null,
+      grid_icon_color: null
     }
   },
   'floral-charm': {
@@ -189,7 +195,8 @@ export const COLOR_PALETTES = {
       stats_consumer_2_background: null,
       grid_icon_import: null,
       grid_icon_export: null,
-      grid_icon_idle: null
+      grid_icon_idle: null,
+      grid_icon_color: null
     }
   },
 
@@ -217,7 +224,8 @@ export const COLOR_PALETTES = {
       stats_consumer_2_background: null,
       grid_icon_import: null,
       grid_icon_export: null,
-      grid_icon_idle: null
+      grid_icon_idle: null,
+      grid_icon_color: null
     }
   },
 
@@ -245,7 +253,8 @@ export const COLOR_PALETTES = {
       stats_consumer_2_background: null,
       grid_icon_import: null,
       grid_icon_export: null,
-      grid_icon_idle: null
+      grid_icon_idle: null,
+      grid_icon_color: null
     }
   },
 
@@ -273,7 +282,8 @@ export const COLOR_PALETTES = {
       stats_consumer_2_background: null,
       grid_icon_import: null,
       grid_icon_export: null,
-      grid_icon_idle: null
+      grid_icon_idle: null,
+      grid_icon_color: null
     }
   },
 
@@ -301,7 +311,8 @@ export const COLOR_PALETTES = {
       stats_consumer_2_background: null,
       grid_icon_import: null,
       grid_icon_export: null,
-      grid_icon_idle: null
+      grid_icon_idle: null,
+      grid_icon_color: null
     }
   },
 
@@ -329,7 +340,8 @@ export const COLOR_PALETTES = {
       stats_consumer_2_background: null,
       grid_icon_import: null,
       grid_icon_export: null,
-      grid_icon_idle: null
+      grid_icon_idle: null,
+      grid_icon_color: null
     }
   },
 
@@ -357,7 +369,8 @@ export const COLOR_PALETTES = {
       stats_consumer_2_background: null,
       grid_icon_import: null,
       grid_icon_export: null,
-      grid_icon_idle: null
+      grid_icon_idle: null,
+      grid_icon_color: null
     }
   },
 
@@ -385,7 +398,8 @@ export const COLOR_PALETTES = {
       stats_consumer_2_background: null,
       grid_icon_import: null,
       grid_icon_export: null,
-      grid_icon_idle: null
+      grid_icon_idle: null,
+      grid_icon_color: null
     }
   },
   'custom': {
@@ -412,7 +426,8 @@ export const COLOR_PALETTES = {
       stats_consumer_2_background: null,
       grid_icon_import: null,
       grid_icon_export: null,
-      grid_icon_idle: null
+      grid_icon_idle: null,
+      grid_icon_color: null
     }
   }
 };
@@ -438,6 +453,7 @@ export function getCardColors(config) {
   if (config.grid_icon_import_color) colors = { ...colors, grid_icon_import: toColor(config.grid_icon_import_color) };
   if (config.grid_icon_export_color) colors = { ...colors, grid_icon_export: toColor(config.grid_icon_export_color) };
   if (config.grid_icon_idle_color) colors = { ...colors, grid_icon_idle: toColor(config.grid_icon_idle_color) };
+  if (config.grid_icon_color) colors = { ...colors, grid_icon_color: toColor(config.grid_icon_color) };
 
   return colors;
 }

--- a/dist/solar-bar-card.js
+++ b/dist/solar-bar-card.js
@@ -1,6 +1,6 @@
 // solar-bar-card.js
 // Enhanced Solar Bar Card with battery support and animated flow visualization
-// Version 2.7.3 - Configurable grid icon colors, bar segment text spacing
+// Version 2.7.4 - Grid icon tower color config, fix idle circle transparency
 
 import { COLOR_PALETTES, getCardColors, getPaletteOptions } from './solar-bar-card-palettes.js';
 
@@ -1264,7 +1264,7 @@ class SolarBarCard extends HTMLElement {
 
         .grid-icon ha-icon {
           --mdc-icon-size: 20px;
-          color: var(--grid-icon-color, black);
+          color: ${colors.grid_icon_color || 'black'};
         }
 
         .grid-icon.import {
@@ -1280,7 +1280,6 @@ class SolarBarCard extends HTMLElement {
         .grid-icon.idle {
           background: var(--disabled-text-color, #9e9e9e);
           box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-          opacity: 0.6;
         }
 
         .bar-segment {
@@ -1996,6 +1995,7 @@ class SolarBarCardEditor extends HTMLElement {
       grid_icon_import_color: "Grid Icon Import Color",
       grid_icon_export_color: "Grid Icon Export Color",
       grid_icon_idle_color: "Grid Icon Idle Color",
+      grid_icon_color: "Grid Icon Tower Color",
       show_stats: "Show Individual Stats",
       show_legend: "Show Legend",
       show_legend_values: "Show Legend Values",
@@ -2071,9 +2071,10 @@ class SolarBarCardEditor extends HTMLElement {
       consumption_history_entity: "Daily home consumption sensor (kWh) - shows total energy used today",
       show_net_indicator: "Show colored indicator on import/export tile (green=net exporter, red=net importer)",
       show_grid_icon_always: "Always show grid icon next to the solar bar, even when there is no import or export. Icon turns grey when idle.",
-      grid_icon_import_color: "Custom background color for the grid icon when importing.",
-      grid_icon_export_color: "Custom background color for the grid icon when exporting.",
-      grid_icon_idle_color: "Custom background color for the grid icon when idle (no import/export).",
+      grid_icon_import_color: "Custom background color for the grid icon circle when importing.",
+      grid_icon_export_color: "Custom background color for the grid icon circle when exporting.",
+      grid_icon_idle_color: "Custom background color for the grid icon circle when idle (no import/export).",
+      grid_icon_color: "Color of the transmission tower icon inside the circle (default: black).",
       show_stats: "Display individual power statistics above the bar (dynamic layout - adapts to configured entities)",
       show_legend: "Display color-coded legend below the bar",
       show_legend_values: "Show current kW values in the legend",
@@ -2275,7 +2276,8 @@ class SolarBarCardEditor extends HTMLElement {
             schema: [
               { name: "grid_icon_import_color", selector: { color_rgb: {} } },
               { name: "grid_icon_export_color", selector: { color_rgb: {} } },
-              { name: "grid_icon_idle_color", selector: { color_rgb: {} } }
+              { name: "grid_icon_idle_color", selector: { color_rgb: {} } },
+              { name: "grid_icon_color", selector: { color_rgb: {} } }
             ]
           },
           {


### PR DESCRIPTION
- Add `grid_icon_color` config option for the transmission tower icon color inside the circle (eliminates card-mod flicker)
- Remove opacity: 0.6 from idle circle that caused transparent/washed out appearance
- Clarify existing color option descriptions to say "circle" explicitly

https://claude.ai/code/session_01YQVgeszBh1qYfFMYGSs1NB