### PR TITLE
fix: eliminate tower icon color flash on load

### DIFF
--- a/dist/solar-bar-card.js
+++ b/dist/solar-bar-card.js
@@ -1677,7 +1677,7 @@ class SolarBarCard extends HTMLElement {
                      data-entity="${grid_power_entity || (hasGridImport ? import_entity : export_entity) || import_entity || export_entity}"
                      data-action-key="${hasGridImport ? 'import' : 'export'}"
                      title="${hasGridImport ? `${this.getLabel('grid_import')}: ${gridImportPower.toFixed(decimal_places)}kW - ${this.getLabel('click_history')}` : hasGridExport ? `${this.getLabel('grid_export')}: ${exportPower.toFixed(decimal_places)}kW - ${this.getLabel('click_history')}` : this.getLabel('grid_idle')}">
-                  <ha-icon icon="mdi:transmission-tower"></ha-icon>
+                  <ha-icon icon="mdi:transmission-tower" style="color: ${colors.grid_icon_color || 'black'}"></ha-icon>
                 </div>
               ` : ''}
               ${showBatteryFlow ? `

--- a/releases.md
+++ b/releases.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 - **Grid icon circle colors not applying**: Fixed `grid_icon_import_color`, `grid_icon_export_color`, and `grid_icon_idle_color` config options being ignored. The colors were set as duplicate CSS rules that got overridden by later selectors. They are now applied directly in the grid icon class definitions so configured colors always take effect.
+- **Tower icon color flash on load**: Fixed the transmission tower icon briefly appearing white before the configured `grid_icon_color` took effect. The color is now set as an inline style so it applies immediately, before the `ha-icon` web component finishes rendering its shadow DOM.
 
 ---
 


### PR DESCRIPTION
Apply grid_icon_color as inline style on the ha-icon element so the configured color is present before the web component's shadow DOM renders. Prevents the brief white flash on page load.

https://claude.ai/code/session_01YQVgeszBh1qYfFMYGSs1NB