### PR TITLE
Fix production_center crash: hasSolar used before declaration

### DIFF
--- a/dist/solar-bar-card.js
+++ b/dist/solar-bar-card.js
@@ -930,6 +930,7 @@ class SolarBarCard extends HTMLElement {
       const gridX = positions.grid !== undefined ? positions.grid : null;
 
       // Calculate solar drop origin: bar center or middle of filled production
+      const hasSolar = solarProduction > 0;
       let solarX = solarBarCenter;
       if (energy_flow_origin === 'production_center' && hasSolar) {
         const productionPct = solarHomePercent + solarEvPercent + exportPercent + batteryChargePercent;
@@ -951,7 +952,6 @@ class SolarBarCard extends HTMLElement {
       }
 
       // Flow state flags
-      const hasSolar = solarProduction > 0;
       const solarToHomeFlow = hasSolar && totalHouseConsumption > 0 && show_house_icon;
       const exportFlow = hasSolar && exportPower > flowThreshold && gridX !== null;
       const batteryChargeFlow = hasSolar && batteryCharging && battX !== null;


### PR DESCRIPTION
hasSolar was referenced at line 934 inside the production_center origin block but declared later at line 954. Moved the declaration before its first use so the card renders with either origin setting.

https://claude.ai/code/session_01YQVgeszBh1qYfFMYGSs1NB