### PR TITLE
EV icon ready states use palette grid import/export colors

### DIFF
--- a/dist/solar-bar-card.js
+++ b/dist/solar-bar-card.js
@@ -1812,13 +1812,13 @@ class SolarBarCard extends HTMLElement {
         }
 
         .ev-icon.ready-half {
-          background: #f59e0b;
+          background: ${colors.grid_icon_import || 'linear-gradient(135deg, var(--grid-usage-color), var(--grid-usage-color))'};
           box-shadow: 0 2px 4px rgba(0,0,0,0.2);
           opacity: 1;
         }
 
         .ev-icon.ready-full {
-          background: #22c55e;
+          background: ${colors.grid_icon_export || 'linear-gradient(135deg, var(--solar-export-color), var(--solar-export-color))'};
           box-shadow: 0 2px 4px rgba(0,0,0,0.2);
           opacity: 1;
         }


### PR DESCRIPTION
Replace hardcoded #f59e0b/#22c55e with colors.grid_icon_import and colors.grid_icon_export (with the same CSS var fallbacks as the grid icon) so the EV circle stays consistent with the active palette.

https://claude.ai/code/session_01KzHGCqDMds6xGpyhB3Sn6w