### PR TITLE
v2.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A real-time solar power distribution card for Home Assistant. Visualize how your solar energy flows between home consumption, grid export/import, battery storage, EV charging, and additional consumers — all in a single, intuitive bar chart.
 
 ![HACS Badge](https://img.shields.io/badge/HACS-Custom-orange.svg)
-![Version](https://img.shields.io/badge/Version-2.9.3-blue.svg)
+![Version](https://img.shields.io/badge/Version-2.9.4-blue.svg)
 [![GitHub Issues](https://img.shields.io/github/issues/0xAHA/solar-bar-card.svg)](https://github.com/0xAHA/solar-bar-card/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/0xAHA/solar-bar-card.svg?style=social)](https://github.com/0xAHA/solar-bar-card)
 

--- a/dist/solar-bar-card.js
+++ b/dist/solar-bar-card.js
@@ -1,6 +1,6 @@
 // solar-bar-card.js
 // Enhanced Solar Bar Card with battery support and animated flow visualization
-// Version 2.9.3 - EV charging icon colour follows grid state + config UI label polish
+// Version 2.9.4 - Console badge style + config label fixes
 
 import { COLOR_PALETTES, getCardColors, getPaletteOptions } from './solar-bar-card-palettes.js';
 
@@ -3152,4 +3152,8 @@ window.customCards.push({
   documentationURL: 'https://github.com/0xAHA/solar-bar-card'
 });
 
-console.info('%c🌞 Solar Bar Card v2.9.3 loaded!', 'color: #4CAF50; font-weight: bold;');
+console.info(
+  '%c SOLAR-BAR-CARD %c v2.9.4 ',
+  'color:#fff;background:#f57c00;font-weight:700;padding:2px 4px;border-radius:4px 0 0 4px;',
+  'color:#f57c00;background:#fff3e0;font-weight:700;padding:2px 4px;border-radius:0 4px 4px 0;'
+);

--- a/dist/solar-bar-card.js
+++ b/dist/solar-bar-card.js
@@ -2653,8 +2653,7 @@ class SolarBarCardEditor extends HTMLElement {
       grid_icon_export_color: "Grid Icon Export Color",
       grid_icon_idle_color: "Grid Icon Idle Color",
       grid_icon_color: "Grid Icon Tower Color",
-      ev_icon_idle_color: "EV Icon Idle Color",
-      ev_icon_charging_color: "EV Icon Charging Color",
+      ev_icon_color: "EV Car Icon Color",
       show_stats: "Show Individual Stats",
       show_legend: "Show Legend",
       show_legend_values: "Show Legend Values",
@@ -2742,8 +2741,7 @@ class SolarBarCardEditor extends HTMLElement {
       grid_icon_export_color: "Custom background color for the grid icon circle when exporting.",
       grid_icon_idle_color: "Custom background color for the grid icon circle when idle (no import/export).",
       grid_icon_color: "Color of the transmission tower icon inside the circle (default: black).",
-      ev_icon_idle_color: "Custom color for the EV icon when idle (not charging, no excess solar).",
-      ev_icon_charging_color: "Custom color for the EV icon when actively charging.",
+      ev_icon_color: "Color of the car symbol inside the EV circle (default: black). The circle background is automatically orange when importing from the grid or green when exporting/net-zero.",
       show_stats: "Display individual power statistics above the bar (dynamic layout - adapts to configured entities)",
       show_legend: "Display color-coded legend below the bar",
       show_legend_values: "Show current kW values in the legend",
@@ -2957,8 +2955,6 @@ class SolarBarCardEditor extends HTMLElement {
               { name: "grid_icon_export_color", selector: { color_rgb: {} } },
               { name: "grid_icon_idle_color", selector: { color_rgb: {} } },
               { name: "grid_icon_color", selector: { color_rgb: {} } },
-              { name: "ev_icon_idle_color", selector: { color_rgb: {} } },
-              { name: "ev_icon_charging_color", selector: { color_rgb: {} } },
               { name: "ev_icon_color", selector: { color_rgb: {} } }
             ]
           },

--- a/dist/solar-bar-card.js
+++ b/dist/solar-bar-card.js
@@ -2662,6 +2662,8 @@ class SolarBarCardEditor extends HTMLElement {
       show_bar_values: "Show Bar Values",
       decimal_places: "Decimal Places",
       battery_soc_decimal_places: "Battery SOC Decimals",
+      power_unit: "Power Unit",
+      show_power_unit: "Show Power Unit",
       stats_border_radius: "Stats Tile Border Radius",
       show_stats_detail: "Show Stats Detail Row",
       stats_detail_position: "Stats Detail Position",

--- a/releases.md
+++ b/releases.md
@@ -8,6 +8,12 @@
 
 - **Console badge restyled**: The browser console load message now uses a two-tone pill badge — orange filled label on the left, light orange version number on the right — matching the style used by other popular HA custom cards.
 
+### Bug Fixes
+
+- **EV icon car colour now configurable in the editor**: `ev_icon_color` controls the colour of the car symbol inside the EV circle and was already functional, but was missing from the editor label map so it appeared as the raw key name `ev_icon_color`. It now shows as **EV Car Icon Color** with a helper tooltip.
+
+- **Removed ghost EV colour options**: `ev_icon_idle_color` and `ev_icon_charging_color` appeared in the config UI but were never wired up — they did nothing. Both have been removed. The circle background is handled automatically (grey when idle, orange when importing, green when net-zero/exporting) and the car symbol colour is controlled by **EV Car Icon Color**.
+
 ---
 
 ## v2.9.3 — Green Light, Orange Light

--- a/releases.md
+++ b/releases.md
@@ -2,6 +2,14 @@
 
 <a href="https://www.buymeacoffee.com/0xAHA" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>
 
+## v2.9.4 — Dressed to Console
+
+### Improvements
+
+- **Console badge restyled**: The browser console load message now uses a two-tone pill badge — orange filled label on the left, light orange version number on the right — matching the style used by other popular HA custom cards.
+
+---
+
 ## v2.9.3 — Green Light, Orange Light
 
 ### Improvements


### PR DESCRIPTION
Solar Bar Card - Releases
Buy Me A Coffee

v2.9.4 — Dressed to Console
Improvements
Console badge restyled: The browser console load message now uses a two-tone pill badge — orange filled label on the left, light orange version number on the right — matching the style used by other popular HA custom cards.
v2.9.3 — Green Light, Orange Light
Improvements
EV charging icon now shows grid state colour: While the EV is actively charging, the circle was always grey. It now mirrors the grid icon — orange when the grid is importing (you're drawing power from the grid to charge), green when net-zero or exporting (the car is running on solar/battery). The yellow glow remains in both states to indicate active charging.

Config editor label polish: The power unit dropdown now reads "Unit of measure" with options "kW — kilowatts" and "W — watts". The unit toggle reads "Show unit label (kW / W)" for clarity. The decimal places dropdown now has a proper "Power decimal places" label instead of displaying the raw field name.

