### PR TITLE
perf: eliminate SVG Gaussian blur GPU drain on battery flow animation

### DIFF
--- a/dist/solar-bar-card.js
+++ b/dist/solar-bar-card.js
@@ -1429,7 +1429,7 @@ class SolarBarCard extends HTMLElement {
           padding: 0 12px;
           height: 32px;
           margin-bottom: 4px;
-          transition: all 0.3s ease;
+          transition: border-color 0.3s ease, background-color 0.3s ease;
         }
 
         .battery-indicator.charging {
@@ -1478,7 +1478,8 @@ class SolarBarCard extends HTMLElement {
           bottom: 1px;
           background: linear-gradient(90deg, #4CAF50, #8BC34A);
           border-radius: 1px;
-          transition: width 0.3s ease;
+          transition: transform 0.3s ease;
+          transform-origin: left center;
         }
 
         .battery-level.low {
@@ -1568,9 +1569,10 @@ class SolarBarCard extends HTMLElement {
           left: 0;
           top: 0;
           bottom: 0;
+          width: 100%;
           background: linear-gradient(90deg, var(--battery-bar-color), var(--battery-bar-color));
-          transition: width 0.3s ease;
-          border-radius: 16px;
+          transform-origin: left center;
+          transition: transform 0.3s ease;
         }
 
         .bar-overlay-label {
@@ -1639,7 +1641,7 @@ class SolarBarCard extends HTMLElement {
           align-items: center;
           justify-content: center;
           font-size: 18px;
-          transition: all 0.3s ease;
+          transition: transform 0.3s ease, background-color 0.3s ease, box-shadow 0.3s ease;
           flex-shrink: 0;
           cursor: pointer;
         }
@@ -1676,7 +1678,7 @@ class SolarBarCard extends HTMLElement {
           align-items: center;
           justify-content: center;
           font-size: 18px;
-          transition: all 0.3s ease;
+          transition: transform 0.3s ease, background-color 0.3s ease, box-shadow 0.3s ease;
           flex-shrink: 0;
           cursor: pointer;
           background: var(--solar-usage-color);
@@ -1737,7 +1739,7 @@ class SolarBarCard extends HTMLElement {
           color: white;
           font-size: 10px;
           font-weight: 600;
-          transition: all 0.3s ease;
+          transition: width 0.3s ease, opacity 0.3s ease;
           text-shadow: 0 1px 2px rgba(0,0,0,0.5);
           position: relative;
           z-index: 3;
@@ -1790,7 +1792,7 @@ class SolarBarCard extends HTMLElement {
           justify-content: center;
           flex-shrink: 0;
           cursor: pointer;
-          transition: all 0.3s ease;
+          transition: transform 0.3s ease, background-color 0.3s ease, opacity 0.3s ease;
           background: var(--disabled-text-color, #9e9e9e);
           box-shadow: 0 2px 4px rgba(0,0,0,0.1);
         }
@@ -2165,7 +2167,7 @@ class SolarBarCard extends HTMLElement {
               ` : ''}
               ${hasBattery && show_battery_indicator ? `
                 <div class="battery-bar-wrapper ${isIdle ? 'standby' : ''}" style="width: ${batteryBarWidth}%" data-entity="${battery_soc_entity}" data-action-key="battery" title="${this.getLabel('click_history')}">
-                  <div class="battery-bar-fill ${batteryCharging ? 'charging' : batteryDischarging ? 'discharging' : batterySOC < 20 ? 'low' : batterySOC < 50 ? 'medium' : ''}" style="width: ${batterySOC}%"></div>
+                  <div class="battery-bar-fill ${batteryCharging ? 'charging' : batteryDischarging ? 'discharging' : batterySOC < 20 ? 'low' : batterySOC < 50 ? 'medium' : ''}" style="transform: scaleX(${(batterySOC / 100).toFixed(4)})"></div>
                   ${shouldShowSegmentText(batteryBarWidth, `${batterySOC.toFixed(battery_soc_decimal_places)} %`, 100) ? `<div class="bar-overlay-label">${batterySOC.toFixed(battery_soc_decimal_places)} %</div>` : ''}
                 </div>
               ` : ''}
@@ -2206,21 +2208,11 @@ class SolarBarCard extends HTMLElement {
               ` : ''}
               ${showBatteryFlow ? `
                 <svg class="flow-line-container" width="100%" height="32" viewBox="0 0 100 32" preserveAspectRatio="xMidYMid slice" style="z-index: 2;">
-                  <defs>
-                    <filter id="batteryGlow">
-                      <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
-                      <feMerge>
-                        <feMergeNode in="coloredBlur"/>
-                        <feMergeNode in="SourceGraphic"/>
-                      </feMerge>
-                    </filter>
-                  </defs>
                   <path id="batteryFlowPath"
                         d="${batteryFlowPath}"
                         stroke="${batteryFlowColor}"
                         stroke-width="4"
                         fill="none"
-                        filter="url(#batteryGlow)"
                         stroke-dasharray="4,4"
                         opacity="0.7"
                         vector-effect="non-scaling-stroke">

--- a/dist/solar-bar-card.js
+++ b/dist/solar-bar-card.js
@@ -1,6 +1,6 @@
 // solar-bar-card.js
 // Enhanced Solar Bar Card with battery support and animated flow visualization
-// Version 2.9.4 - Console badge style + config label fixes
+// Version 2.9.5 - GPU performance fix: remove Gaussian blur from animated SVG path
 
 import { COLOR_PALETTES, getCardColors, getPaletteOptions } from './solar-bar-card-palettes.js';
 
@@ -3138,7 +3138,7 @@ window.customCards.push({
 });
 
 console.info(
-  '%c SOLAR-BAR-CARD %c v2.9.4 ',
+  '%c SOLAR-BAR-CARD %c v2.9.5 ',
   'color:#fff;background:#f57c00;font-weight:700;padding:2px 4px;border-radius:4px 0 0 4px;',
   'color:#f57c00;background:#fff3e0;font-weight:700;padding:2px 4px;border-radius:0 4px 4px 0;'
 );

--- a/releases.md
+++ b/releases.md
@@ -2,6 +2,18 @@
 
 <a href="https://www.buymeacoffee.com/0xAHA" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>
 
+## v2.9.5 — Blur No More
+
+### Performance
+
+- **Massive GPU usage reduction**: The battery flow animation was consuming up to 50% GPU on modern hardware (including an RTX 3090) due to a `feGaussianBlur` SVG filter applied to a path that was simultaneously running a 60fps SMIL `stroke-dashoffset` animation. When a filter is combined with a SMIL animation, the browser cannot cache the rasterized output — it re-rasterizes the full element and re-runs the blur kernel on every frame, indefinitely. The filter has been removed; the animated dashed line and flow particles are fully preserved.
+
+- **Eliminated `transition: all` on interactive elements**: Five elements (`.battery-indicator`, `.grid-icon`, `.house-icon`, `.bar-segment`, `.ev-icon`) used `transition: all 0.3s ease`, which forces the browser to track and interpolate every CSS property simultaneously on any state change — including paint-heavy properties like `box-shadow` and `background`. Each is now scoped to only the properties that actually animate (`transform`, `background-color`, `border-color`, etc.).
+
+- **Battery SOC bar now uses GPU compositing**: The battery fill bar switched from `width: X%` (triggers layout reflow) to `transform: scaleX(X)` (GPU-composited, zero layout cost). The redundant `border-radius` on the fill was also removed — the parent container's `overflow: hidden` already handles clipping.
+
+---
+
 ## v2.9.4 — Dressed to Console
 
 ### Improvements


### PR DESCRIPTION
## Problem

Users reported up to **50% GPU usage on an RTX 3090** from what should be a trivial single-card animation. That's a clear sign of a pathological rendering loop, not normal animation overhead.

## Root Cause

The battery flow SVG path had **two things simultaneously**:
1. A `feGaussianBlur` filter (`<filter id="batteryGlow">`, stdDeviation=3)
2. A `stroke-dashoffset` SMIL animation running at 60fps indefinitely (dur=0.6s)

When an SVG filter is applied to a SMIL-animated element, the browser cannot cache the result — it must **re-rasterize the element and re-run the blur kernel every single frame**. A Gaussian blur is O(n) per pixel with a large kernel, applied across the entire filter primitive subregion on every frame. This is the textbook cause of runaway GPU load from a "simple" SVG animation.

## Fixes

### 1. Remove `feGaussianBlur` from animated path (primary fix)
- Deleted the entire `<defs><filter id="batteryGlow">...</filter></defs>` block
- Removed `filter="url(#batteryGlow)"` from the path element
- The animated dashed stroke remains fully visible without the glow — this was purely cosmetic overhead

### 2. Replace `transition: all 0.3s ease` with explicit property lists
Affected: `.battery-indicator`, `.grid-icon`, `.house-icon`, `.bar-segment`, `.ev-icon`

`transition: all` forces the browser to compute and interpolate **every** CSS property (including `box-shadow`, `background`, `width`, `border`) simultaneously on any state change. Replaced with scoped lists:
- Icon elements: `transition: transform 0.3s ease, background-color 0.3s ease, box-shadow 0.3s ease`
- Bar segments: `transition: width 0.3s ease, opacity 0.3s ease`
- Battery indicator: `transition: border-color 0.3s ease, background-color 0.3s ease`

### 3. Battery fill bar: `width` → `transform: scaleX()` (avoids reflow)
- `.battery-bar-fill` now uses `width: 100%; transform-origin: left center; transition: transform 0.3s ease`
- Inline style changed from `style="width: ${batterySOC}%"` → `style="transform: scaleX(${batterySOC/100})"`
- `transform` is GPU-composited and never triggers layout recalculation
- The `border-radius: 16px` on the fill was also removed — the parent wrapper already has `overflow: hidden` which handles clipping

## Test plan
- [ ] Battery flow animation still visible with dashed moving line and particles
- [ ] Battery SOC bar fills correctly at 0%, 10%, 50%, 100%
- [ ] Battery charging/discharging/low/medium color states still apply correctly
- [ ] Grid/house/EV icon hover effects (scale, background change) still animate
- [ ] Bar segments animate width on data updates
- [ ] GPU usage significantly reduced (should be near 0% at idle)

https://claude.ai/code/session_01F2f5zuwGmegkxP3ezcZXYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2f5zuwGmegkxP3ezcZXYC)_