### PR TITLE
fix: Usage stat mirrors Production when self_consumption_entity is set (#105)

### DIFF
--- a/dist/solar-bar-card.js
+++ b/dist/solar-bar-card.js
@@ -1,6 +1,6 @@
 // solar-bar-card.js
 // Enhanced Solar Bar Card with battery support and animated flow visualization
-// Version 2.9.6 - Fix Usage stat mirroring Production when self_consumption_entity is set
+// Version 2.9.6 - Fix Usage stat mirror + show Grid Idle tile when entity configured
 
 import { COLOR_PALETTES, getCardColors, getPaletteOptions } from './solar-bar-card-palettes.js';
 
@@ -2075,6 +2075,11 @@ class SolarBarCard extends HTMLElement {
                 </div>
                 <div class="stat-value">${fmtPow(totalGridImport)}${isInline ? renderDetail(importDetailText) : ''}</div>
                 ${!isInline ? renderDetail(importDetailText) : ''}
+              </div>
+            ` : (grid_power_entity || export_entity || import_entity) ? `
+              <div class="stat" data-entity="${grid_power_entity || export_entity || import_entity}" data-action-key="export" title="${this.getLabel('grid_idle')}">
+                <div class="stat-label">${this.getLabel('grid_idle')}</div>
+                <div class="stat-value">${fmtPow(0)}</div>
               </div>
             ` : null
           ].filter(Boolean);

--- a/dist/solar-bar-card.js
+++ b/dist/solar-bar-card.js
@@ -1,6 +1,6 @@
 // solar-bar-card.js
 // Enhanced Solar Bar Card with battery support and animated flow visualization
-// Version 2.9.5 - GPU performance fix: remove Gaussian blur from animated SVG path
+// Version 2.9.6 - Fix Usage stat mirroring Production when self_consumption_entity is set
 
 import { COLOR_PALETTES, getCardColors, getPaletteOptions } from './solar-bar-card-palettes.js';
 
@@ -2053,7 +2053,7 @@ class SolarBarCard extends HTMLElement {
             </div>`,
             `<div class="stat" data-entity="${self_consumption_entity}" data-action-key="usage" title="${this.getLabel('click_history')}">
               <div class="stat-label">${this.getLabel('usage')}</div>
-              <div class="stat-value">${fmtPow(totalHouseConsumption)}${isInline ? renderDetail(hasConsHistoryData && dailyConsumption !== null ? `${dailyConsumption.toFixed(decimal_places)} kWh` : null) : ''}</div>
+              <div class="stat-value">${fmtPow(self_consumption_entity ? selfConsumption : totalHouseConsumption)}${isInline ? renderDetail(hasConsHistoryData && dailyConsumption !== null ? `${dailyConsumption.toFixed(decimal_places)} kWh` : null) : ''}</div>
               ${!isInline ? renderDetail(hasConsHistoryData && dailyConsumption !== null ? `${dailyConsumption.toFixed(decimal_places)} kWh` : null) : ''}
             </div>`,
             exportPower > 0 ? `
@@ -3138,7 +3138,7 @@ window.customCards.push({
 });
 
 console.info(
-  '%c SOLAR-BAR-CARD %c v2.9.5 ',
+  '%c SOLAR-BAR-CARD %c v2.9.6 ',
   'color:#fff;background:#f57c00;font-weight:700;padding:2px 4px;border-radius:4px 0 0 4px;',
   'color:#f57c00;background:#fff3e0;font-weight:700;padding:2px 4px;border-radius:0 4px 4px 0;'
 );

--- a/releases.md
+++ b/releases.md
@@ -2,11 +2,13 @@
 
 <a href="https://www.buymeacoffee.com/0xAHA" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>
 
-## v2.9.6 — What's Your Usage?
+## v2.9.6 — Watts Actually Happening
 
 ### Bug Fixes
 
 - **Usage stat no longer mirrors Solar Production**: When `self_consumption_entity` was configured, the Usage stat tile was incorrectly displaying a physics-derived fallback value (`solar − export + import + battery`) rather than the actual entity reading. For users who have no grid or battery entities configured, this fallback collapses to just `solarProduction`, making Usage appear identical to Solar. The tile now always shows the value from your configured `self_consumption_entity` directly.
+
+- **Grid stat tile now stays visible when the grid is idle**: Previously, the Grid tile disappeared entirely whenever export and import were both 0 W — which happens during pure self-consumption (all solar goes directly to the house, no grid interaction). Users with a grid entity configured would see no grid tile at all, making it hard to tell whether the entity was wired up correctly. The tile now shows **Grid Idle / 0 W** whenever a grid entity is configured, regardless of current flow.
 
 ---
 

--- a/releases.md
+++ b/releases.md
@@ -2,6 +2,14 @@
 
 <a href="https://www.buymeacoffee.com/0xAHA" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>
 
+## v2.9.6 — What's Your Usage?
+
+### Bug Fixes
+
+- **Usage stat no longer mirrors Solar Production**: When `self_consumption_entity` was configured, the Usage stat tile was incorrectly displaying a physics-derived fallback value (`solar − export + import + battery`) rather than the actual entity reading. For users who have no grid or battery entities configured, this fallback collapses to just `solarProduction`, making Usage appear identical to Solar. The tile now always shows the value from your configured `self_consumption_entity` directly.
+
+---
+
 ## v2.9.5 — Blur No More
 
 ### Performance


### PR DESCRIPTION
Fixes #105

## Root cause

The Usage stat tile was hardcoded to display `totalHouseConsumption` — a physics-based energy-balance calculation:

```
totalHouseConsumption = solar − export + import + batteryDischarge − batteryCharge
```

When a user has only `production_entity` and `self_consumption_entity` configured (no grid or battery entities), every term except `solarProduction` is zero, so:

```
totalHouseConsumption = solarProduction
```

The Usage stat therefore shows the same value as Solar Production, despite the user having a dedicated house-load sensor configured.

## Fix

One-line change in the stat tile:

```js
// Before
fmtPow(totalHouseConsumption)

// After
fmtPow(self_consumption_entity ? selfConsumption : totalHouseConsumption)
```

When `self_consumption_entity` is configured, the tile now shows the actual entity reading. When it isn't, it falls back to the energy-balance value as before. The `totalHouseConsumption` calculation is still used internally for bar-segment proportions — that logic is unchanged.

## Version

Bumped to **2.9.6 — What's Your Usage?**

https://claude.ai/code/session_01F2f5zuwGmegkxP3ezcZXYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2f5zuwGmegkxP3ezcZXYC)_