### PR TITLE
perf: v2.9.7 GPU fixes — CSS animations, will-change, disable_animation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A real-time solar power distribution card for Home Assistant. Visualize how your solar energy flows between home consumption, grid export/import, battery storage, EV charging, and additional consumers — all in a single, intuitive bar chart.
 
 ![HACS Badge](https://img.shields.io/badge/HACS-Custom-orange.svg)
-![Version](https://img.shields.io/badge/Version-2.9.4-blue.svg)
+![Version](https://img.shields.io/badge/Version-2.9.7-blue.svg)
 [![GitHub Issues](https://img.shields.io/github/issues/0xAHA/solar-bar-card.svg)](https://github.com/0xAHA/solar-bar-card/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/0xAHA/solar-bar-card.svg?style=social)](https://github.com/0xAHA/solar-bar-card)
 

--- a/dist/solar-bar-card.js
+++ b/dist/solar-bar-card.js
@@ -1,6 +1,6 @@
 // solar-bar-card.js
 // Enhanced Solar Bar Card with battery support and animated flow visualization
-// Version 2.9.6 - Fix Usage stat mirror + show Grid Idle tile when entity configured
+// Version 2.9.7 - GPU performance: disable_animation, CSS dash animation, will-change, prefers-reduced-motion
 
 import { COLOR_PALETTES, getCardColors, getPaletteOptions } from './solar-bar-card-palettes.js';
 


### PR DESCRIPTION
## Summary

Follows up on v2.9.5 (`feGaussianBlur` removal). User confirms GPU usage still elevated after that fix. This PR addresses all remaining animation-related GPU costs.

- **`disable_animation` config toggle** — stops all SMIL particle and dash animations while keeping the card live-updating. Exposed in both YAML and the visual editor. Documented in `EDITOR_DESCRIPTIONS`.
- **Battery dash animation migrated from SMIL to CSS** — `stroke-dashoffset` `<animate>` replaced with an injected `@keyframes` rule; browsers can compositor-thread CSS animations, SMIL runs on the main thread.
- **`will-change: transform` on all animated particles** — energy flow ellipses and battery circles now carry this hint so the browser promotes them to GPU compositor layers before motion starts.
- **Single box-shadow on `.ev-icon.charging`** — double-blur glow (`0 0 10px` + `0 0 22px`) collapsed to `0 0 12px`; halves blur passes on state transitions.
- **`prefers-reduced-motion` media query** — users with OS-level reduced motion preference get all animations automatically disabled, no config needed.
- **Version references updated** — file header comment (line 3) and README badge both bumped to 2.9.7 (were stale at 2.9.6 and 2.9.4 respectively).

## Test plan

- [ ] Enable `show_energy_flow: true` and `show_battery_flow: true`, open Chrome DevTools Performance tab, record 5s — confirm "Composite Layers" dominates over "Paint"
- [ ] Set `disable_animation: true` in card YAML — all particle motion and dash animation stops; card still shows live values
- [ ] Toggle `disable_animation` in the visual editor — works without YAML edit
- [ ] Set OS reduced-motion accessibility preference — animations stop automatically without any card config
- [ ] Console badge shows `v2.9.7`
- [ ] README badge shows `2.9.7`

https://claude.ai/code/session_01F2f5zuwGmegkxP3ezcZXYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2f5zuwGmegkxP3ezcZXYC)_