### PR TITLE
v3.0.1 "Double Booked" — fix Usage figure inconsistency between stat tile, bar, and legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A real-time solar power distribution card for Home Assistant. Visualize how your solar energy flows between home consumption, grid export/import, battery storage, EV charging, and additional consumers — all in a single, intuitive bar chart.
 
 ![HACS Badge](https://img.shields.io/badge/HACS-Custom-orange.svg)
-![Version](https://img.shields.io/badge/Version-3.0.0-blue.svg)
+![Version](https://img.shields.io/badge/Version-3.0.1-blue.svg)
 [![GitHub Issues](https://img.shields.io/github/issues/0xAHA/solar-bar-card.svg)](https://github.com/0xAHA/solar-bar-card/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/0xAHA/solar-bar-card.svg?style=social)](https://github.com/0xAHA/solar-bar-card)
 

--- a/dist/solar-bar-card.js
+++ b/dist/solar-bar-card.js
@@ -1,6 +1,6 @@
 // solar-bar-card.js
 // Enhanced Solar Bar Card with battery support and animated flow visualization
-// Version 3.0.0 - Card tap action for header navigation
+// Version 3.0.1 - Usage figure now consistent across stat tile, bar, and legend
 
 import { COLOR_PALETTES, getCardColors, getPaletteOptions } from './solar-bar-card-palettes.js';
 
@@ -762,6 +762,14 @@ class SolarBarCard extends HTMLElement {
     // (self_consumption_entity on many inverters reports solar self-consumption, not total house consumption)
     const effectiveConsumption = Math.max(selfConsumption, totalHouseConsumption);
     const nonEvConsumption = Math.max(0, effectiveConsumption - evUsage);
+
+    // Single source of truth for the "Usage" figure shown on the Usage stat tile,
+    // house icon, and legend. EV charging is broken out as its own tile/segment
+    // elsewhere, so this must exclude it to avoid double-counting EV power under
+    // the "Usage" label. Prefers the user's configured self_consumption_entity
+    // (which may already exclude other loads via a helper) and otherwise falls
+    // back to the physics-derived house consumption with EV subtracted.
+    const houseUsageDisplay = self_consumption_entity ? selfConsumption : nonEvConsumption;
 
     // Calculate how much solar feeds the load directly
     const solarToLoad = Math.min(solarProduction, effectiveConsumption);
@@ -2085,7 +2093,7 @@ class SolarBarCard extends HTMLElement {
             </div>`,
             `<div class="stat" data-entity="${self_consumption_entity}" data-action-key="usage" title="${this.getLabel('click_history')}">
               <div class="stat-label">${this.getLabel('usage')}</div>
-              <div class="stat-value">${fmtPow(self_consumption_entity ? selfConsumption : totalHouseConsumption)}${isInline ? renderDetail(hasConsHistoryData && dailyConsumption !== null ? `${dailyConsumption.toFixed(decimal_places)} kWh` : null) : ''}</div>
+              <div class="stat-value">${fmtPow(houseUsageDisplay)}${isInline ? renderDetail(hasConsHistoryData && dailyConsumption !== null ? `${dailyConsumption.toFixed(decimal_places)} kWh` : null) : ''}</div>
               ${!isInline ? renderDetail(hasConsHistoryData && dailyConsumption !== null ? `${dailyConsumption.toFixed(decimal_places)} kWh` : null) : ''}
             </div>`,
             exportPower > 0 ? `
@@ -2203,7 +2211,7 @@ class SolarBarCard extends HTMLElement {
                 <div class="house-icon ${hasGridImport && solarProduction <= 0 ? 'importing' : ''}"
                      data-entity="${self_consumption_entity}"
                      data-action-key="usage"
-                     title="${this.getLabel('usage')}: ${fmtPow(totalHouseConsumption)} - ${this.getLabel('click_history')}">
+                     title="${this.getLabel('usage')}: ${fmtPow(houseUsageDisplay)} - ${this.getLabel('click_history')}">
                   <ha-icon icon="mdi:home" style="color: white"></ha-icon>
                 </div>
               ` : ''}
@@ -2298,7 +2306,7 @@ class SolarBarCard extends HTMLElement {
               ${solarToHome > 0 ? `
                 <div class="legend-item" data-entity="${self_consumption_entity}" data-action-key="usage" title="${this.getLabel('click_history')}">
                   <div class="legend-color solar-home-color"></div>
-                  <span>${this.getLabel('usage')}${show_legend_values ? ` ${fmtPow(totalHouseConsumption)}` : ''}</span>
+                  <span>${this.getLabel('usage')}${show_legend_values ? ` ${fmtPow(houseUsageDisplay)}` : ''}</span>
                 </div>
               ` : ''}
               ${exportPower > 0 ? `
@@ -3255,7 +3263,7 @@ window.customCards.push({
 });
 
 console.info(
-  '%c SOLAR-BAR-CARD %c v3.0.0 ',
+  '%c SOLAR-BAR-CARD %c v3.0.1 ',
   'color:#fff;background:#f57c00;font-weight:700;padding:2px 4px;border-radius:4px 0 0 4px;',
   'color:#f57c00;background:#fff3e0;font-weight:700;padding:2px 4px;border-radius:0 4px 4px 0;'
 );

--- a/releases.md
+++ b/releases.md
@@ -2,6 +2,14 @@
 
 <a href="https://www.buymeacoffee.com/0xAHA" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>
 
+## v3.0.1 — Double Booked
+
+### Bug Fixes
+
+- **"Usage" figure now consistent across the stat tile, house icon, and legend**: When an EV charger was configured, the Usage stat tile at the top of the card correctly showed house-only consumption (either from your `self_consumption_entity`, or the physics-derived total with EV subtracted), but the bar's house icon tooltip and the legend's "Usage" entry always showed the full physics-based `solar − export + import + battery` total — which already includes EV charging. Since EV charging is also broken out as its own tile/segment, this made the Usage value look inflated and inconsistent between the top of the card and the bar/legend below, especially for users whose `self_consumption_entity` is a helper that nets out EV power. All three now derive from the same value, and EV usage is no longer double-counted under the "Usage" label. The bar's separate "Total usage" scale marker (used with `show_usage_indicator`) is intentionally unchanged, as it's meant to reflect whole-home draw including EV. Resolves [#112](https://github.com/0xAHA/solar-bar-card/issues/112).
+
+---
+
 ## v3.0.0 — Tap to Navigate
 
 - **Card-level tap action (`tap_action_card`)**: The header title is now clickable when `tap_action_card` is configured. Set it to `navigate` to jump to a dedicated solar dashboard without interfering with the individual entity tap actions on stats tiles, bar segments, or legend items. Requires `show_header: true`. Resolves [#110](https://github.com/0xAHA/solar-bar-card/issues/110).


### PR DESCRIPTION
## Summary

Fixes #112 — the "Usage" value shown in the bar's house icon tooltip and the legend didn't match the "Usage" stat tile at the top of the card.

**Root cause:** the Usage stat tile used `self_consumption_entity ? selfConsumption : totalHouseConsumption` (house-only, or a physics-derived fallback), but the bar's house icon and the legend's "Usage" entry always used `totalHouseConsumption` directly — a physics-based `solar − export + import + battery` figure that includes **all** home load, EV charging included. Since EV charging is also broken out as its own tile/segment, the bar/legend "Usage" value double-counted EV power under the "Usage" label, while the top stat tile (especially when the user's `self_consumption_entity` is a helper that already nets out EV) did not. That's exactly what was reported in #112: a helper-based house-consumption sensor read correctly at the top of the card but not in the bar/legend.

**Fix:** introduced a single `houseUsageDisplay` value (`self_consumption_entity ? selfConsumption : nonEvConsumption`) and used it consistently for the stat tile, house icon tooltip, and legend "Usage" entry. The bar's separate "Total usage" scale marker (`show_usage_indicator`) is intentionally left using `totalHouseConsumption`, since that marker is explicitly meant to represent whole-home draw including EV.

## Changes

- `dist/solar-bar-card.js`: added `houseUsageDisplay`, applied it to the 3 "Usage" display sites, bumped version to 3.0.1
- `README.md`: version badge bumped to 3.0.1
- `releases.md`: added v3.0.1 "Double Booked" changelog entry

## Test plan

- [ ] Configure `self_consumption_entity` (via a helper subtracting EV load) + `ev_charger_sensor`, confirm the Usage stat tile, house icon tooltip, and legend "Usage" value now all match
- [ ] Without `self_consumption_entity` configured, confirm Usage falls back to the physics-derived value with EV excluded, and no longer double-counts EV
- [ ] Confirm the bar's "Total usage" scale indicator (`show_usage_indicator: true`) still reflects whole-home consumption including EV, unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_0131w6KsFPgApmeqTdsYejXf)_